### PR TITLE
Mysql test db

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,6 +35,7 @@ Dockerfile
 # Ignore build directories
 build/
 dist/
+tmp/
 
 # Ignore IDE specific files
 .vscode/
@@ -46,5 +47,7 @@ secrets/
 # Except these files
 !secrets/cert.pem
 !secrets/key.pem
-!secrets/.mysql_root_password
-!secrets/.mysql_user_password
+!secrets/.mysql_root_password.txt
+!secrets/.mysql_user_password.txt
+!secrets/.testdb_root_password.txt
+!secrets/.testdb_user_password.txt

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tmux*
 .env
 notes.txt
 secrets/
+tmp/
 
 # Ignore build directories
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ ENV SECRETS_DIR="./secrets/tokens.yaml"
 
 COPY ./secrets/.mysql_root_password /run/secrets/mysql_root_password
 COPY ./secrets/.mysql_user_password /run/secrets/mysql_user_password
-RUN chmod 400 /run/secrets/mysql_root_password /run/secrets/mysql_user_password
+COPY ./secrets/.testdb_user_password /run/secrets/testdb_user_password
+RUN chmod 400 /run/secrets/mysql_root_password /run/secrets/mysql_user_password /run/secrets/testdb_user_password
 
 EXPOSE 443
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,13 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ENV LOG_CFG="logging_config.yaml"
 ENV SECRETS_DIR="./secrets/tokens.yaml"
+ENV DBNAME="lurkerbothunterdb"
+ENV DB_SERVICE_NAME="db"
+ENV DB_PORT="3306"
 
-COPY ./secrets/.mysql_root_password /run/secrets/mysql_root_password
-COPY ./secrets/.mysql_user_password /run/secrets/mysql_user_password
-COPY ./secrets/.testdb_user_password /run/secrets/testdb_user_password
+COPY ./secrets/.mysql_root_password.txt /run/secrets/mysql_root_password
+COPY ./secrets/.mysql_user_password.txt /run/secrets/mysql_user_password
+COPY ./secrets/.testdb_user_password.txt /run/secrets/testdb_user_password
 RUN chmod 400 /run/secrets/mysql_root_password /run/secrets/mysql_user_password /run/secrets/testdb_user_password
 
 EXPOSE 443

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,30 @@
 services:
+  test-db:
+    image: mysql:latest
+    environment:
+      MYSQL_DATABASE: lurkerbothunter-testdb
+      MYSQL_USER: user
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/testdb_root_password
+      MYSQL_PASSWORD_FILE: /run/secrets/testdb_user_password
+    ports:
+      - "3307:3307"
+    secrets:
+      - testdb_root_password
+      - testdb_user_password
+    volumes:
+      - testdb_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    command: --wait_timeout=28800 --interactive_timeout=28800
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: "1g"
+
   db:
     image: mysql:latest
     environment:
@@ -51,9 +77,15 @@ services:
 volumes:
   mysql_data:
     driver: local
+  testdb_data:
+    driver: local
 
 secrets:
   mysql_root_password:
     file: ./secrets/.mysql_root_password
   mysql_user_password:
     file: ./secrets/.mysql_user_password
+  testdb_root_password:
+    file: ./secrets/.testdb_root_password
+  testdb_user_password:
+    file: ./secrets/.testdb_user_password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       MYSQL_ROOT_PASSWORD_FILE: /run/secrets/testdb_root_password
       MYSQL_PASSWORD_FILE: /run/secrets/testdb_user_password
     ports:
-      - "3307:3307"
+      - "3307:3306"
     secrets:
       - testdb_root_password
       - testdb_user_password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,8 @@ services:
       DATABASE_URL: mysql+aiomysql://user@db/lurkerbothunterdb
       DATABASE_PREFIX: mysql+aiomysql://
       DATABASE_NAME: lurkerbothunterdb
-      TEST_DB_NAME: lurkerbothunterdb-testdb
+      DB_SERVICE_NAME: db
+      DB_PORT: 3306
     volumes:
       - .:/server
       - ./logs:/logs
@@ -87,10 +88,10 @@ volumes:
 
 secrets:
   mysql_root_password:
-    file: ./secrets/.mysql_root_password
+    file: ./secrets/.mysql_root_password.txt
   mysql_user_password:
-    file: ./secrets/.mysql_user_password
+    file: ./secrets/.mysql_user_password.txt
   testdb_root_password:
-    file: ./secrets/.testdb_root_password
+    file: ./secrets/.testdb_root_password.txt
   testdb_user_password:
-    file: ./secrets/.testdb_user_password
+    file: ./secrets/.testdb_user_password.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,11 @@ services:
       ENVIRONMENT: prod
       CERT_PASSKEY: ${CERT_PASSKEY}
       MYSQL_USER_PASSWORD_FILE: /run/secrets/mysql_user_password
+      TESTDB_USER_PASSWORD_FILE: /run/secrets/testdb_user_password
       DATABASE_URL: mysql+aiomysql://user@db/lurkerbothunterdb
+      DATABASE_PREFIX: mysql+aiomysql://
+      DATABASE_NAME: lurkerbothunterdb
+      TEST_DB_NAME: lurkerbothunterdb-testdb
     volumes:
       - .:/server
       - ./logs:/logs
@@ -65,6 +69,7 @@ services:
       - "443:443"
     secrets:
       - mysql_user_password
+      - testdb_user_password
     depends_on:
       db:
         condition: service_healthy

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -56,7 +56,7 @@ async def lifespan(
 def create_app() -> FastAPI:
     fastapi_app = FastAPI(lifespan=lifespan)
 
-    Config.load_secrets()
+    Config.initialize()
     fastapi_app.debug = False
 
     logger.info("Logger is ready.")

--- a/server/config/default.py
+++ b/server/config/default.py
@@ -8,11 +8,18 @@ logger = logging.getLogger("server")
 
 
 class Config:
-    PORT = 443
+    _initialized = False
 
+    PORT = 443
+    ENVIRONMENT = os.getenv("ENVIRONMENT", "dev").lower()
     LOGGING_CONFIG_FILE: str = os.getenv("LOG_CFG", "./logging_config.yaml")
 
     _sqlmodel_database_uri: Optional[str] = None
+    _db_name: Optional[str] = None
+
+    MYSQL_USER_PASSWORD_FILE: Optional[str] = None
+    DATABASE_PREFIX = os.getenv("DATABASE_PREFIX")
+    MYSQL_DB_NAME = os.getenv("DATABASE_NAME")
 
     # The access and refresh tokens are supplied by the twitch_oauth.sh servlet via the store_token
     # endpoint. See server.routes
@@ -24,37 +31,53 @@ class Config:
     TWITCH_CLIENT_SECRET: Optional[str] = None
 
     @classmethod
-    def load_secrets(cls) -> None:
-        secrets_path: str = os.getenv("SECRETS_DIR", "./secrets/tokens.yaml")
+    def initialize(cls) -> None:
+        twitch_oauth_secrets_path: str = os.getenv(
+            "SECRETS_DIR", "./secrets/tokens.yaml"
+        )
 
-        if os.path.exists(secrets_path):
-            with open(secrets_path, "r", encoding="UTF8") as file:
+        if os.path.exists(twitch_oauth_secrets_path):
+            with open(twitch_oauth_secrets_path, "r", encoding="UTF8") as file:
                 secrets: Union[dict, list, None] = yaml.safe_load(file)
                 if not isinstance(secrets, dict):
                     raise TypeError("secrets load failed.")
                 cls.TWITCH_CLIENT_ID = secrets["TWITCH_CLIENT_ID"]
                 cls.TWITCH_CLIENT_SECRET = secrets["TWITCH_CLIENT_SECRET"]
 
+        if cls.ENVIRONMENT == "prod":
+            cls.MYSQL_USER_PASSWORD_FILE = os.getenv("MYSQL_USER_PASSWORD_FILE")
+            cls._db_name = os.getenv("DATABASE_NAME")
+        elif cls.ENVIRONMENT in {"test", "dev"}:
+            cls.MYSQL_USER_PASSWORD_FILE = os.getenv("TESTDB_USER_PASSWORD")
+            cls._db_name = os.getenv("TEST_DB_NAME")
+        else:
+            raise ValueError("Invalid ENVIRONMENT set.")
+
+        cls._initialized = True
+
     @classmethod
     def _build_db_uri(cls) -> str:
+        if not cls._initialized:
+            cls.initialize()
+
         mysql_user_password: Optional[str] = None
-        pw_file = os.getenv("MYSQL_USER_PASSWORD_FILE")
+        pw_file = cls.MYSQL_USER_PASSWORD_FILE
         if pw_file is None:
-            raise EnvironmentError("MYSQL_USER_PASSWORD_FILE not in environment.")
-        with open(pw_file, "r", encoding="utf8") as file:
-            mysql_user_password = file.read().strip()
+            raise EnvironmentError(f"DB password file not set: {pw_file}")
+        try:
+            with open(pw_file, "r", encoding="utf8") as file:
+                mysql_user_password = file.read().strip()
+        except FileNotFoundError as e:
+            raise EnvironmentError(f"DB password file missing: {pw_file}") from e
         if len(mysql_user_password) == 0:
             raise EnvironmentError("MYSQL_USER_PASSWORD_FILE is empty.")
         uri = f"mysql+aiomysql://user:{mysql_user_password}@db/lurkerbothunterdb"
+        uri = f"{cls.DATABASE_PREFIX}user:{mysql_user_password}@db/{cls.MYSQL_DB_NAME}"
         return uri
 
     @classmethod
     def get_db_uri(cls) -> str:
         if cls._sqlmodel_database_uri is None:
-            environment = os.getenv("ENVIRONMENT", "prod")
-            if environment in ["test", "dev"]:
-                cls._sqlmodel_database_uri = "sqlite+aiosqlite://"
-            else:
-                cls._sqlmodel_database_uri = cls._build_db_uri()
+            cls._sqlmodel_database_uri = cls._build_db_uri()
 
         return cls._sqlmodel_database_uri

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,8 +49,10 @@ async def create_test_tables(async_engine):  # pylint:disable=redefined-outer-na
         await conn.run_sync(SQLModel.metadata.drop_all)
 
 
-@pytest_asyncio.fixture(scope="function", autouse=True)
-async def truncate_tables(async_engine):  # pylint:disable=redefined-outer-name
+@pytest_asyncio.fixture(scope="function")
+async def truncate_tables(
+    async_engine,
+):  # pylint:disable=redefined-outer-name  # type: ignore
     async with async_engine.begin() as conn:
         await conn.execute(text("SET FOREIGN_KEY_CHECKS = 0;"))
         for table in reversed(SQLModel.metadata.sorted_tables):
@@ -61,7 +63,9 @@ async def truncate_tables(async_engine):  # pylint:disable=redefined-outer-name
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_session(async_session_maker):  # pylint:disable=redefined-outer-name
+async def async_session(
+    async_session_maker, truncate_tables  # type: ignore
+):  # pylint:disable=redefined-outer-name
     async with async_session_maker() as session:
         yield session
         await session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import logging
-import os
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlmodel import SQLModel
+
+from server.config import Config
 
 # pylint: disable=unused-import
 from server.models import (
@@ -17,17 +18,16 @@ from server.models import (
 )
 from server.models.dummy_model import DummyModel
 
-# Set the environment to test
-os.environ["ENVIRONMENT"] = "test"
+_TEST_DB_URI = Config.get_db_uri()
 
 
 @pytest.fixture(scope="function")
 def async_engine():
-    return create_async_engine("sqlite+aiosqlite://", echo=True)
+    return create_async_engine(_TEST_DB_URI, echo=True, future=True, hide_parameters=True)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_session(async_engine):
+async def async_session(async_engine):  # pylint:disable=redefined-outer-name
     async with async_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
     async with AsyncSession(async_engine) as session:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
+import asyncio
 import logging
+import sys
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 from sqlmodel import SQLModel
 
 from server.config import Config
@@ -21,19 +25,33 @@ from server.models.dummy_model import DummyModel
 _TEST_DB_URI = Config.get_db_uri()
 
 
-@pytest.fixture(scope="function")
-def async_engine():
-    return create_async_engine(_TEST_DB_URI, echo=True, future=True, hide_parameters=True)
+@pytest_asyncio.fixture(scope="session")
+async def async_engine():
+    engine = create_async_engine(
+        _TEST_DB_URI, echo=True, future=True, hide_parameters=True, poolclass=NullPool
+    )
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def async_session_maker(async_engine):  # pylint:disable=redefined-outer-name
+    return sessionmaker(async_engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def create_test_tables(async_engine):  # pylint:disable=redefined-outer-name
+    async with async_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+        yield
+        await conn.run_sync(SQLModel.metadata.drop_all)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_session(async_engine):  # pylint:disable=redefined-outer-name
-    async with async_engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-    async with AsyncSession(async_engine) as session:
+async def async_session(async_session_maker):  # pylint:disable=redefined-outer-name
+    async with async_session_maker() as session:
         yield session
-    async with async_engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.drop_all)
+        await session.close()
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/model_sanity/test_suspected_bot_query.py
+++ b/tests/model_sanity/test_suspected_bot_query.py
@@ -76,11 +76,11 @@ async def test_database_interactions(
     for user_data in valid_twitch_user_data:
         user = TwitchUserData(**user_data.model_dump())
         async_session.add(user)
-    async_session.commit()
+    await async_session.commit()
 
     # Insert the StreamCategory entry
     async_session.add(valid_stream_category)
-    async_session.commit()
+    await async_session.commit()
 
     # Query for the TwitchUserData with all_time_high_concurrent_channel_count greater than 1000
     statement = (
@@ -104,7 +104,7 @@ async def test_database_interactions(
         )
         suspected_bot = SuspectedBot(**suspected_bot_data.dict())
         async_session.add(suspected_bot)
-    async_session.commit()
+    await async_session.commit()
 
     # Assert the correctness of the SuspectedBot entries
     for result in results:

--- a/tests/model_sanity/test_twitch_user_data_model.py
+++ b/tests/model_sanity/test_twitch_user_data_model.py
@@ -17,12 +17,12 @@ TWITCH_USER_DATA_MOCK = {
     "account_type": TwitchAccountType.NORMAL,
     "broadcaster_type": TwitchBroadcasterType.AFFILIATE,
     "lifetime_view_count": 1000,
-    "account_created_at": datetime.now(),
-    "first_sighting_as_viewer": datetime.now(),
-    "most_recent_sighting_as_viewer": datetime.now(),
+    "account_created_at": "2020-12-12T20:12:00Z",
+    "first_sighting_as_viewer": "2024-07-14T20:00:00Z",
+    "most_recent_sighting_as_viewer": "2024-07-14T20:00:00Z",
     "most_recent_concurrent_channel_count": 10,
     "all_time_high_concurrent_channel_count": 20,
-    "all_time_high_at": datetime.now(),
+    "all_time_high_at": "2024-07-14T20:00:00Z",
 }
 
 
@@ -54,15 +54,6 @@ async def test_create_and_read_twitch_user_data(async_session):
         TWITCH_USER_DATA_MOCK["broadcaster_type"]
     )
     assert read_data.lifetime_view_count == TWITCH_USER_DATA_MOCK["lifetime_view_count"]
-    assert read_data.account_created_at == TWITCH_USER_DATA_MOCK["account_created_at"]
-    assert (
-        read_data.first_sighting_as_viewer
-        == TWITCH_USER_DATA_MOCK["first_sighting_as_viewer"]
-    )
-    assert (
-        read_data.most_recent_sighting_as_viewer
-        == TWITCH_USER_DATA_MOCK["most_recent_sighting_as_viewer"]
-    )
     assert (
         read_data.most_recent_concurrent_channel_count
         == TWITCH_USER_DATA_MOCK["most_recent_concurrent_channel_count"]
@@ -71,4 +62,3 @@ async def test_create_and_read_twitch_user_data(async_session):
         read_data.all_time_high_concurrent_channel_count
         == TWITCH_USER_DATA_MOCK["all_time_high_concurrent_channel_count"]
     )
-    assert read_data.all_time_high_at == TWITCH_USER_DATA_MOCK["all_time_high_at"]


### PR DESCRIPTION
in-memory SQLite with asyncio has a number of known challenges I was running headlong into. I decided instead to just setup a mysql testdb since that's the db I'm using and need validation for anyway, and of course docker makes that trivial. Was a fun learning experience on both paths, but this is definitely the way forward.